### PR TITLE
Keep docker-compose default network for project-local communication

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -74,6 +74,9 @@ services:
         uid: '{{ .UID }}'
         gid: '{{ .GID }}'
     image: ${DDEV_WEBIMAGE}-${DDEV_SITENAME}-built
+    networks:
+      - default
+      - ddev_default
     cap_add:
       - SYS_PTRACE
     working_dir: "{{ .WebWorkingDir }}"
@@ -182,6 +185,9 @@ services:
   dba:
     container_name: ddev-${DDEV_SITENAME}-dba
     image: $DDEV_DBAIMAGE
+    networks:
+      - default
+      - ddev_default
     working_dir: "{{ .DBAWorkingDir }}"
     restart: "{{ if .AutoRestartContainers }}always{{ else }}no{{ end }}"
     labels:
@@ -213,7 +219,7 @@ services:
       retries: 1
 {{end}}
 networks:
-  default:
+  ddev_default:
     name: ddev_default
     external: true
 volumes:


### PR DESCRIPTION
## The Problem/Issue/Bug:
Unambiguity in name resolution was recently only possible in `ddev`when using `ddev-<projectname>-service` which requires a level of environment-awareness in apps that should usually not be necessary in a container environment.

## How this PR Solves The Problem:

This brings ddev closer to the standard use case of docker-compose networking as described in https://docs.docker.com/compose/networking/.

The "ddev_default" network is now only connected to those services that need connectivity with the router (web, dba).

The "db" service has not been changed explicitly, but it will be in the per-project docker-compose-managed "default" network implicitly. docker-compose will name it "<project>_default".

Contrib-service-recipes that only need per-project networking (via its service name or `ddev-<project>-<servicename>:<port>`) will not need any changes.
Those that want to be reached externally via http[s]://<project>:<port> need to add the "ddev_external" network:
```
networks:
 - default
 - ddev_default
```
The "trigger-word" for those that need this change is the special proxy-env "VIRTUAL_HOST" (see `./containers/ddev-router/nginx.tmpl`).


## Manual Testing Instructions:

Create multiple ddev projects (`ddev config` with all defaults).
Run `ddev exec ping db` from them.

You should see answers only from the project-local "db" container.
With ddev 1.18.1 you would see answers from other "db" containers.


## Automated Testing Overview:
Automated tests could test networking with multiple started projects.


## Related Issue Link(s):
#3369
https://github.com/docker/compose/issues/8935

## Remarks/tbd:
* This change tries to minimize code changes. For improved self-documentation the network should rather be called "ddev_proxy" or "ddev_frontend".
* Does the ssh-agent container have to be on that network? Or even on any?
* Usage of docker-compose service "links" should not be necessary any more.